### PR TITLE
Switch reference to use candidate from applicant

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,17 +273,17 @@ Returns a list of all invite codes. Requires a valid JWT access token in the Aut
 ]
 ```
 
-### Applicant Registration
+### Candidate Registration
 
-**POST** `/api/applicants/register/`
+**POST** `/api/candidates/register/`
 
-Registers a new applicant using an invite code. On success, the user is added to the Applicant group and the invite code's usage count is incremented. Returns a success message. No authentication required.
+Registers a new candidate using an invite code. On success, the user is added to the Candidate group and the invite code's usage count is incremented. Returns a success message. No authentication required.
 
 **Example request body:**
 ```json
 {
-  "invite_code": "APPLICANT2024",
-  "email": "applicant@example.com",
+  "invite_code": "CANDIDATE2024",
+  "email": "candidate@example.com",
   "password": "securepassword",
   "first_name": "Jane",
   "last_name": "Doe"

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -124,7 +124,7 @@ class InviteCodeSerializer(serializers.ModelSerializer):
         return obj.created_by.name if obj.created_by else None
 
 
-class ApplicantRegistrationSerializer(serializers.Serializer):
+class CandidateRegistrationSerializer(serializers.Serializer):
     invite_code = serializers.CharField()
     email = serializers.EmailField()
     password = serializers.CharField(write_only=True)
@@ -162,7 +162,7 @@ class ApplicantRegistrationSerializer(serializers.Serializer):
             status="active",
             is_active=True,
         )
-        group, _ = Group.objects.get_or_create(name="Applicant")
+        group, _ = Group.objects.get_or_create(name="Candidate")
         user.groups.add(group)
         user.save()
         return user

--- a/api/tests/test_candidate_registration.py
+++ b/api/tests/test_candidate_registration.py
@@ -8,12 +8,12 @@ from api.models import InviteCode
 User = get_user_model()
 
 
-class ApplicantRegistrationTests(TestCase):
+class CandidateRegistrationTests(TestCase):
     def setUp(self):
         self.client = APIClient()
         self.invite = InviteCode.objects.create(
-            code="APPLICANT2024",
-            event="Spring 2024 Applicant Registration",
+            code="CANDIDATE2024",
+            event="Spring 2024 Candidate Registration",
             status="active",
             used_count=0,
             expires_at="2024-12-31T23:59:59Z",
@@ -26,66 +26,66 @@ class ApplicantRegistrationTests(TestCase):
                 is_active=True,
             ),
         )
-        Group.objects.get_or_create(name="Applicant")
+        Group.objects.get_or_create(name="Candidate")
         self.valid_payload = {
-            "invite_code": "APPLICANT2024",
-            "email": "applicant@example.com",
+            "invite_code": "CANDIDATE2024",
+            "email": "candidate@example.com",
             "password": "securepassword",
             "first_name": "Jane",
             "last_name": "Doe",
         }
 
-    def test_applicant_registration_success(self):
+    def test_candidate_registration_success(self):
         response = self.client.post(
-            "/api/applicants/register/", self.valid_payload, format="json"
+            "/api/candidates/register/", self.valid_payload, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertTrue(User.objects.filter(email="applicant@example.com").exists())
-        user = User.objects.get(email="applicant@example.com")
-        self.assertTrue(user.groups.filter(name="Applicant").exists())
+        self.assertTrue(User.objects.filter(email="candidate@example.com").exists())
+        user = User.objects.get(email="candidate@example.com")
+        self.assertTrue(user.groups.filter(name="Candidate").exists())
         self.assertEqual(user.first_name, "Jane")
         self.assertEqual(user.last_name, "Doe")
         self.assertEqual(user.name, "Jane Doe")
-        invite = InviteCode.objects.get(code="APPLICANT2024")
+        invite = InviteCode.objects.get(code="CANDIDATE2024")
         self.assertEqual(invite.used_count, 1)
 
-    def test_applicant_registration_invalid_invite_code(self):
+    def test_candidate_registration_invalid_invite_code(self):
         payload = self.valid_payload.copy()
         payload["invite_code"] = "INVALIDCODE"
-        response = self.client.post("/api/applicants/register/", payload, format="json")
+        response = self.client.post("/api/candidates/register/", payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("invite_code", response.data)
 
-    def test_applicant_registration_inactive_invite_code(self):
+    def test_candidate_registration_inactive_invite_code(self):
         self.invite.status = "expired"
         self.invite.save()
         payload = self.valid_payload.copy()
-        response = self.client.post("/api/applicants/register/", payload, format="json")
+        response = self.client.post("/api/candidates/register/", payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("invite_code", response.data)
 
-    def test_applicant_registration_duplicate_email(self):
+    def test_candidate_registration_duplicate_email(self):
         User.objects.create_user(
-            username="applicant@example.com",
-            email="applicant@example.com",
+            username="candidate@example.com",
+            email="candidate@example.com",
             password="securepassword",
             name="Jane Doe",
             status="active",
             is_active=True,
         )
         response = self.client.post(
-            "/api/applicants/register/", self.valid_payload, format="json"
+            "/api/candidates/register/", self.valid_payload, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("email", response.data)
 
-    def test_applicant_registration_missing_fields(self):
+    def test_candidate_registration_missing_fields(self):
         payload = {
-            "invite_code": "APPLICANT2024",
+            "invite_code": "CANDIDATE2024",
             "email": "missingfields@example.com",
             # Missing password, first_name, last_name
         }
-        response = self.client.post("/api/applicants/register/", payload, format="json")
+        response = self.client.post("/api/candidates/register/", payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("password", response.data)
         self.assertIn("first_name", response.data)

--- a/api/urls.py
+++ b/api/urls.py
@@ -8,7 +8,7 @@ from .views import (
     UserCreateAPIView,
     InviteCodeCreateAPIView,
     InviteCodeListAPIView,
-    ApplicantRegistrationAPIView,
+    CandidateRegistrationAPIView,
     UserMeAPIView,
 )
 
@@ -24,9 +24,9 @@ urlpatterns = [
     ),
     path("invite-codes/", InviteCodeListAPIView.as_view(), name="invite-code-list"),
     path(
-        "applicants/register/",
-        ApplicantRegistrationAPIView.as_view(),
-        name="applicant-register",
+        "candidates/register/",
+        CandidateRegistrationAPIView.as_view(),
+        name="candidate-register",
     ),
     path("user/me/", UserMeAPIView.as_view(), name="user-me"),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -8,7 +8,7 @@ from .serializers import (
     ChurchSerializer,
     UserCreateSerializer,
     InviteCodeSerializer,
-    ApplicantRegistrationSerializer,
+    CandidateRegistrationSerializer,
     UserMeSerializer,
 )
 from rest_framework.views import APIView
@@ -44,8 +44,8 @@ class InviteCodeListAPIView(generics.ListAPIView):
     permission_classes = [IsAuthenticated]
 
 
-class ApplicantRegistrationAPIView(generics.CreateAPIView):
-    serializer_class = ApplicantRegistrationSerializer
+class CandidateRegistrationAPIView(generics.CreateAPIView):
+    serializer_class = CandidateRegistrationSerializer
     permission_classes = [AllowAny]
 
     def create(self, request, *args, **kwargs):


### PR DESCRIPTION
# Description
The frontend app was using the naming convention candidate instead of applicant for the student/applicant user. This PR updates the backend to use the same name for urls and group names for consistency.