### PR TITLE
Implements forced password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,27 @@ Registers a new candidate using an invite code. On success, the user is added to
 }
 ```
 
+### Reset Password (Requires Authentication)
+
+**POST** `/api/reset-password/`
+
+Allows an authenticated user who is required to change their password (e.g., after admin reset or first login) to set a new password.
+
+**Example request body:**
+```json
+{
+  "temporary_password": "oldpassword123",
+  "new_password": "newsecurepassword456"
+}
+```
+
+**Example response:**
+```json
+{
+  "detail": "Password changed successfully."
+}
+```
+
 ### Get Current User Info (Requires Authentication)
 
 **GET** `/api/user/me/`

--- a/api/admin.py
+++ b/api/admin.py
@@ -1,14 +1,21 @@
 from django.contrib import admin
-from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.forms import UserChangeForm, UserCreationForm
 from .models import User, Church, InviteCode
 
 
-class CustomUserAdmin(UserAdmin):
+class CustomUserAdmin(BaseUserAdmin):
     form = UserChangeForm
     add_form = UserCreationForm
     model = User
-    list_display = ["email", "is_active", "is_staff"]  # Adjust as needed
+    # Show all the fields you want, including requires_password_change
+    list_display = BaseUserAdmin.list_display + ("requires_password_change",)
+    fieldsets = BaseUserAdmin.fieldsets + (
+        (None, {"fields": ("requires_password_change",)}),
+    )
+    add_fieldsets = BaseUserAdmin.add_fieldsets + (
+        (None, {"fields": ("requires_password_change",)}),
+    )
 
 
 # Register your models here.

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -66,6 +66,22 @@ class UserCreateSerializer(serializers.ModelSerializer):
         return user
 
 
+class ResetPasswordSerializer(serializers.Serializer):
+    temporary_password = serializers.CharField(write_only=True)
+    new_password = serializers.CharField(write_only=True)
+
+    def validate(self, data):
+        if data["temporary_password"] == data["new_password"]:
+            raise serializers.ValidationError(
+                "New password must be different from the current password."
+            )
+        if len(data["new_password"]) < 8:
+            raise serializers.ValidationError(
+                "New password must be at least 8 characters long."
+            )
+        return data
+
+
 class ChurchSerializer(serializers.ModelSerializer):
     def validate(self, data):
         name = data["name"].strip().lower()

--- a/api/tests/test_reset_password.py
+++ b/api/tests/test_reset_password.py
@@ -1,0 +1,55 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework import status
+from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.tokens import RefreshToken
+
+User = get_user_model()
+
+
+class ResetPasswordAPITests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            email="resetuser@example.com",
+            username="resetuser@example.com",
+            password="oldpassword123",
+            name="Reset User",
+            status="active",
+            requires_password_change=True,
+        )
+        refresh = RefreshToken.for_user(self.user)
+        self.access_token = str(refresh.access_token)
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer " + self.access_token)
+
+    def test_reset_password_success(self):
+        payload = {
+            "temporary_password": "oldpassword123",
+            "new_password": "newsecurepassword456",
+        }
+        response = self.client.post("/api/reset-password/", payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("newsecurepassword456"))
+        self.assertFalse(self.user.requires_password_change)
+
+    def test_reset_password_invalid_temporary_password(self):
+        payload = {
+            "temporary_password": "wrongpassword",
+            "new_password": "newsecurepassword456",
+        }
+        response = self.client.post("/api/reset-password/", payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("oldpassword123"))
+        self.assertTrue(self.user.requires_password_change)
+
+    def test_reset_password_too_short(self):
+        payload = {"temporary_password": "oldpassword123", "new_password": "short"}
+        response = self.client.post("/api/reset-password/", payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("non_field_errors", response.data)
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password("oldpassword123"))
+        self.assertTrue(self.user.requires_password_change)

--- a/api/urls.py
+++ b/api/urls.py
@@ -10,6 +10,7 @@ from .views import (
     InviteCodeListAPIView,
     CandidateRegistrationAPIView,
     UserMeAPIView,
+    ResetPasswordAPIView,
 )
 
 urlpatterns = [
@@ -29,4 +30,5 @@ urlpatterns = [
         name="candidate-register",
     ),
     path("user/me/", UserMeAPIView.as_view(), name="user-me"),
+    path("reset-password/", ResetPasswordAPIView.as_view(), name="reset-password"),
 ]


### PR DESCRIPTION
# Description
Implement force password reset workflow

- Adds `/api/reset-password/` endpoint for authenticated users to change password when required
- Validates temporary password and new password, updates password, and clears `requires_password_change` flag
- Adds unit tests for password reset: success, invalid temp password, and too-short password
- Updates Django admin to allow toggling `requires_password_change` for users
- Updates backend README with reset password API documentation