### PR TITLE
Delete Previous S3 Bucket File

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -302,6 +302,14 @@ class ProfileSerializer(serializers.ModelSerializer):
         return data
 
     def update(self, instance, validated_data):
+        new_image = validated_data.get("profile_image", None)
+        if new_image and instance.profile_image and instance.profile_image != new_image:
+            instance.profile_image.delete(save=False)  # delete old image from S3
+
+        new_resume = validated_data.get("resume", None)
+        if new_resume and instance.resume and instance.resume != new_resume:
+            instance.resume.delete(save=False)  # delete old resume from S3
+    
         return super().update(instance, validated_data)
 
 


### PR DESCRIPTION
# Description
When a candidate user submits a new file for a resume or profile_image, we should ensure we delete the previous value from the S3 bucket storage to ensure we do not end up with an S3 bucket full of orphan files.
