### PR TITLE
Refactors Church Endpoints to use Viewset

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -5,7 +5,7 @@ from rest_framework_simplejwt.views import (
     TokenRefreshView,
 )
 from .views import (
-    ChurchCreateAPIView,
+    ChurchViewSet,
     UserCreateAPIView,
     InviteCodeCreateAPIView,
     InviteCodeListAPIView,
@@ -23,10 +23,10 @@ from .views import (
 router = DefaultRouter()
 router.register(r"jobs", JobViewSet, basename="job")
 router.register(r"mutual-interests", MutualInterestViewSet, basename="mutual-interest")
+router.register(r'churches', ChurchViewSet, basename='church')
 
 
 urlpatterns = [
-    path("churches/create/", ChurchCreateAPIView.as_view(), name="church-create"),
     path("users/create/", UserCreateAPIView.as_view(), name="user-create"),
     path("token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),

--- a/api/views.py
+++ b/api/views.py
@@ -37,10 +37,18 @@ class UserCreateAPIView(generics.CreateAPIView):
     permission_classes = [IsAuthenticated]
 
 
-class ChurchCreateAPIView(generics.CreateAPIView):
+class ChurchViewSet(viewsets.ModelViewSet):
     queryset = Church.objects.all()
     serializer_class = ChurchSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsAdmin]
+
+    def get_queryset(self):
+        # Customize this if you want to filter by current user’s church only, etc.
+        return Church.objects.all()
+
+    def perform_create(self, serializer):
+        # Customize if you want to set a user or other logic
+        serializer.save()
 
 
 class InviteCodeCreateAPIView(generics.CreateAPIView):


### PR DESCRIPTION
# Description
Initial implementation of church creation did not use Django viewset pattern
This PR updates this model to use the viewset patterns
Fixes tests for new url format and for IsAdmin required authentication for church